### PR TITLE
Add `default_use_cache` flag in config

### DIFF
--- a/build_tester/builders/docker_builder.py
+++ b/build_tester/builders/docker_builder.py
@@ -33,7 +33,7 @@ class DockerBuilder:
         self.__image_id = None
 
     @staticmethod
-    def get_builds(config, os_name='docker', build_name='latest'):
+    def get_builds(config, os_name='docker', build_name='latest', default_use_cache=False):
         params = config.get(os_name)
         if params is None:
             return []
@@ -45,13 +45,13 @@ class DockerBuilder:
                 image=params.get('image', os_name),
                 image_version=version,
                 skip=build_name in params.get('skip', []),
-                use_cache=params.get('use_cache', False),
+                use_cache=params.get('use_cache', default_use_cache),
             ),
             params.get('versions', ['latest']),
         ))
 
     @staticmethod
-    def get_docker_builds(config, os_name, build_name, commands):
+    def get_docker_builds(config, os_name, build_name, commands, default_use_cache=False):
         params = config.get(os_name)
         if params is None:
             return []
@@ -66,7 +66,7 @@ class DockerBuilder:
                     image=match.group(2),
                     image_version=match.group(4) or 'latest',
                     skip=build_name in params.get('skip', []),
-                    use_cache=params.get('use_cache', False),
+                    use_cache=params.get('use_cache', default_use_cache),
                 ))
                 break
 

--- a/build_tester/tester.py
+++ b/build_tester/tester.py
@@ -48,6 +48,8 @@ class Tester:
         self.__results_file_name = config.get('results_file_name', 'results.json')
         self.__results_file_path = os.path.join(self.__local_dir_path, self.__results_file_name)
 
+        self.__default_use_cache = config.get('default_use_cache', False)
+
         os_params = config.get('os_params')
         assert config.get('os_params') is not None, 'No OS params in config!'
 
@@ -84,12 +86,23 @@ class Tester:
 
                 # This is to avoid running Docker in Docker or Docker in VirtualBox
                 if 'docker' not in os_name:
-                    builds += DockerBuilder.get_builds(self.__docker_params, os_name, build_name)
-                    builds += VirtualBoxBuilder.get_builds(self.__virtual_box_params, os_name, build_name)
+                    builds += DockerBuilder.get_builds(
+                        self.__docker_params,
+                        os_name, build_name,
+                        self.__default_use_cache,
+                    )
+                    builds += VirtualBoxBuilder.get_builds(
+                        self.__virtual_box_params,
+                        os_name, build_name,
+                    )
 
                 # Find name of image in commands and use it
                 else:
-                    builds += DockerBuilder.get_docker_builds(self.__docker_params, os_name, build_name, commands)
+                    builds += DockerBuilder.get_docker_builds(
+                        self.__docker_params,
+                        os_name, build_name,
+                        commands, self.__default_use_cache,
+                    )
                     commands = []
 
                 if len(builds) == builds_count and self.__debug_mode:


### PR DESCRIPTION
Now it's possible to select default value of `use_cache` Docker configs flag by `default_use_cache` flag.

For example, now you can make config like this:

```json
{
  "default_use_cache": true,
  "os_params": {
    "example_os_1": {
      "docker": {}
    },
    "example_os_2": {
      "docker": {}
    }
  }
}
```

Before the patch, it was necessary to do like this:

```json
{
  "os_params": {
    "example_os_1": {
      "docker": {
        "use_cache": true
      }
    },
    "example_os_2": {
      "docker": {
        "use_cache": true
      }
    }
  }
}
```