### PR TITLE
Refactor README and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ remote/
 archive/
 config*.json
 !config-example.json
+!config-full.json
 *.db
 
 ### JetBrains ###

--- a/README.md
+++ b/README.md
@@ -1,69 +1,29 @@
 # Delivery Checker
 
-This is a program that downloads Tarantool's installation commands
-and tries to run them on different OS.
+This is a program that downloads Tarantool's installation commands and tries to
+run them on different OS.
 
 ## How to run
 
-1. Install Python 3.6 or higher
-2. Install Docker or/and VirtualBox
-2. Change `config.json` if necessary
-3. Run `check.py`
+### Prepare
+
+1. Install Python 3.6 or higher;
+2. Install Docker or/and VirtualBox;
+3. Change `config.json` if necessary.
+
+### Run
+
+1. Run `run_check.py` to check installation;
+2. Run `run_bot.py` to run Telegram bot.
 
 ## Config with all available options
 
-```json
-{
-  "telegram_token": "1234567890:qWerTyuIOpaSDf-ghJKl-qWerTyuIOpaSDf",
-  "commands_url": "https://www.tarantool.io/api/tarantool/info/versions/",
-  "send_to_remote": {
-    "login": "centos",
-    "password": "centos",
-    "host": "123.456.789.012",
-    "archive": "server_name",
-    "remote_dir": "/opt/delivery_checker/remote"
-  },
-  "use_remote_results": false,
-  "os_params": {
-    "example_os": {
-      "docker": {
-        "image": "name_of_docker_image",
-        "versions": [
-          "2020",
-          "latest"
-        ],
-        "skip": [
-          "name_of_build_1",
-          "name_of_build_2"
-        ],
-        "use_cache": false
-      },
-      "virtual_box": {
-        "Name of VirtualBox VM": {
-          "login": "root",
-          "password": "toor",
-          "host": "127.0.0.1",
-          "port": 22,
-          "remote_dir": "/opt/tarantool",
-          "skip_prepare": false,
-          "prepare_timeout": 360,
-          "run_timeout": 60,
-          "skip": [
-            "name_of_build_1",
-            "name_of_build_2"
-          ]
-        },
-        "example_os_vm": {}
-      }
-    }
-  }
-}
-```
+You can find all available config options in
+file [config-full.json](/config-full.json).
 
 ## Example of output
 
-In this case, the process finished with exit code 1 
-because there are some errors.
+For example, you can have output like this:
 
 ```
 OS: freebsd_12.2. Build: pkg_2.4. Elapsed time: 95.85. OK
@@ -74,3 +34,6 @@ OS: os-x_10.12. Build: 2.5. SKIP
 OS: os-x_10.12. Build: 2.6. Elapsed time: 521.86. OK
 OS: docker-hub_2.5. Build: 2.5. Elapsed time: 122.72. OK
 ```
+
+In this case, the process finished with exit code 1 because there are some
+errors.

--- a/config-example.json
+++ b/config-example.json
@@ -1,4 +1,5 @@
 {
+  "telegram_token": "1234567890:qWerTyuIOpaSDf-ghJKl-qWerTyuIOpaSDf",
   "os_params": {
     "amazon-linux": {
       "docker": {
@@ -18,7 +19,13 @@
       }
     },
     "debian": {
-      "docker": {}
+      "docker": {
+        "versions": [
+          "stretch",
+          "buster",
+          "bullseye"
+        ]
+      }
     },
     "docker-hub": {
       "docker": {}
@@ -26,7 +33,8 @@
     "fedora": {
       "docker": {
         "versions": [
-          "31"
+          "31",
+          "32"
         ]
       }
     },

--- a/config-full.json
+++ b/config-full.json
@@ -1,0 +1,66 @@
+
+{
+  "telegram_token": "1234567890:qWerTyuIOpaSDf-ghJKl-qWerTyuIOpaSDf",
+  "telegram_db": {
+    "name": "postgres_db_name",
+    "user": "delivery_checker_bot",
+    "password": "delivery_checker_bot_password",
+    "file": "bot.db"
+  },
+
+  "scripts_dir_path": "./scripts",
+  "prepare_dir_name": "prepare",
+  "install_dir_name": "install",
+
+  "local_dir_path": "./local",
+  "remote_dir_path": "./remote",
+  "archive_dir_path": "./archive",
+  "logs_dir_name": "logs",
+  "tests_dir_name": "tests",
+  "results_file_name": "results.json",
+
+  "commands_url": "https://www.tarantool.io/api/tarantool/info/versions/",
+  "send_to_remote": {
+    "login": "centos",
+    "password": "centos",
+    "host": "123.456.789.012",
+    "archive": "server_name",
+    "remote_dir": "/opt/delivery_checker/remote"
+  },
+  "use_remote_results": false,
+
+  "default_use_cache": false,
+  "os_params": {
+    "example_os": {
+      "docker": {
+        "image": "name_of_docker_image",
+        "versions": [
+          "2020",
+          "latest"
+        ],
+        "skip": [
+          "name_of_build_1",
+          "name_of_build_2"
+        ],
+        "use_cache": false
+      },
+      "virtual_box": {
+        "Name of VirtualBox VM": {
+          "login": "root",
+          "password": "toor",
+          "host": "127.0.0.1",
+          "port": 22,
+          "remote_dir": "/opt/tarantool",
+          "skip_prepare": false,
+          "prepare_timeout": 360,
+          "run_timeout": 60,
+          "skip": [
+            "name_of_build_1",
+            "name_of_build_2"
+          ]
+        },
+        "example_os_vm": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #4

Before the patch, the README was outdated, the configuration examples were too.

Changes:
- updated README instructions;
- updated example of config with all options;
- added the list of Debian versions (with versions later than `Jessie`);
- added version `32` to the list of Fedora versions.