### PR TITLE
Add support of OS X GH Actions runner

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,12 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Clear old files
-        uses: appleboy/ssh-action@master
+        uses: garygrossgarten/github-action-ssh@release
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          script: |
+          privateKey: ${{ secrets.SSH_KEY }}
+          command: |
             cd ${{ secrets.REMOTE_PATH }}
             find . -maxdepth 1 \
               -not -name '.' \
@@ -23,42 +23,49 @@ jobs:
               -not -name 'archive' \
               -print0 | sudo xargs -0 rm -rfv --
       - name: Send new files
-        uses: appleboy/scp-action@master
+        uses: garygrossgarten/github-action-scp@release
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          source: "*,!.*"
-          target: "${{ secrets.REMOTE_PATH }}/"
+          privateKey: ${{ secrets.SSH_KEY }}
+          local: "./"
+          remote: "${{ secrets.REMOTE_PATH }}/"
       - name: Install dependences
-        uses: appleboy/ssh-action@master
+        uses: garygrossgarten/github-action-ssh@release
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          script: |
+          privateKey: ${{ secrets.SSH_KEY }}
+          command: |
             cd ${{ secrets.REMOTE_PATH }}
+            git reset --hard
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade pip
             pip install -r requirements.txt
       - name: Check config
-        uses: appleboy/ssh-action@master
+        uses: garygrossgarten/github-action-ssh@release
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          script: |
+          privateKey: ${{ secrets.SSH_KEY }}
+          command: |
             cd ${{ secrets.REMOTE_PATH }}
             ls config.json || cp config-example.json config.json
       - name: Restart bot service
-        uses: appleboy/ssh-action@master
+        uses: garygrossgarten/github-action-ssh@release
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          script: |
+          privateKey: ${{ secrets.SSH_KEY }}
+          command: |
             if [ -n "${{ secrets.TG_BOT_NAME }}" ]; then
-              echo "Restarting ${{ secrets.TG_BOT_NAME }} service"
-              sudo systemctl restart ${{ secrets.TG_BOT_NAME }}
+              if [ "$(uname -s)" -eq "Linux" ]; then
+                echo "Restarting '${{ secrets.TG_BOT_NAME }}' service"
+                sudo systemctl restart ${{ secrets.TG_BOT_NAME }}
+              fi
+              if [ "$(uname -s)" -eq "Darwin" ]; then
+                echo "Restarting '${{ secrets.TG_BOT_NAME }}' Launch Agent"
+                sudo launchctl restart ${{ secrets.TG_BOT_NAME }}
+              fi
             fi

--- a/.github/workflows/running.yml
+++ b/.github/workflows/running.yml
@@ -7,16 +7,15 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Run delivery checker
-        uses: appleboy/ssh-action@master
+        uses: garygrossgarten/github-action-ssh@release
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          command_timeout: 360m
-          script: |
+          privateKey: ${{ secrets.SSH_KEY }}
+          command: |
             cd ${{ secrets.REMOTE_PATH }}
             source venv/bin/activate
-            python3 check.py
+            ./run_check.sh
             export EXIT_CODE=$?
             sudo chown -R ${{ secrets.USERNAME }}:${{ secrets.USERNAME }} local
             exit $EXIT_CODE

--- a/config-example.json
+++ b/config-example.json
@@ -1,5 +1,4 @@
 {
-  "telegram_token": "1234567890:qWerTyuIOpaSDf-ghJKl-qWerTyuIOpaSDf",
   "os_params": {
     "amazon-linux": {
       "docker": {
@@ -42,7 +41,7 @@
       "virtual_box": {
         "freebsd_12.2": {
           "port": 10023,
-          "prepare_timeout": 900,
+          "prepare_timeout": 2700,
           "run_timeout": 900
         }
       }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-docker~=4.4.0
+docker~=5.0.0
 requests~=2.25.0
 paramiko~=2.7.2
 pytelegrambotapi~=3.7.4
 peewee~=3.14.0
-emoji~=0.6.0
+emoji~=1.2.0


### PR DESCRIPTION
Some GitHub Actions can only run on Linux runners.

Now CI works not only on Linux runners, but also on OS X runners.