### PR TITLE
Fix checker for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ OS: freebsd_12.2. Build: pkg_2.4. Elapsed time: 95.85. OK
 OS: freebsd_12.2. Build: ports_2.4. Elapsed time: 355.99. TIMEOUT
 OS: amazon-linux_2. Build: script_2.5. Elapsed time: 85.43. ERROR
 OS: amazon-linux_2. Build: script_1.10. Elapsed time: 88.83. ERROR
-OS: os-x_10.12. Build: 2.5. SKIP
-OS: os-x_10.12. Build: 2.6. Elapsed time: 521.86. OK
+OS: mac-os_11.0. Build: 2.5. SKIP
+OS: mac-os_11.0. Build: 2.6. Elapsed time: 521.86. OK
 OS: docker-hub_2.5. Build: 2.5. Elapsed time: 122.72. OK
 ```
 

--- a/build_tester/builders/virtual_box.py
+++ b/build_tester/builders/virtual_box.py
@@ -11,7 +11,7 @@ from build_tester.helpers.ssh import Credentials, SshClient
 VirtualBoxInfo = namedtuple(
     typename='VirtualBoxInfo',
     field_names=(
-        'os_name', 'build_name', 'vm_name', 'credentials', 'remote_dir',
+        'os_name', 'build_name', 'vm_name', 'credentials', 'remote_dir', 'shell_path',
         'skip_prepare', 'prepare_timeout', 'run_timeout', 'skip',
     ),
 )
@@ -34,7 +34,11 @@ class VirtualBoxBuilder:
         self.log = log_func
 
         self.__shell_client = ShellClient(log_func=log_func)
-        self.__ssh_client = SshClient(self.build_info.credentials, log_func=self.log)
+        self.__ssh_client = SshClient(
+            self.build_info.credentials,
+            log_func=self.log,
+            shell_path=self.build_info.shell_path,
+        )
 
     @staticmethod
     def get_builds(config, os_name, build_name):
@@ -54,6 +58,7 @@ class VirtualBoxBuilder:
                     port=vm_params[1].get('port', 10022),
                 ),
                 remote_dir=vm_params[1].get('remote_dir', '/opt/tarantool'),
+                shell_path=vm_params[1].get('shell_path', '/bin/sh'),
                 skip_prepare=vm_params[1].get('skip_prepare'),
                 prepare_timeout=vm_params[1].get('prepare_timeout'),
                 run_timeout=vm_params[1].get('run_timeout'),

--- a/build_tester/helpers/ssh.py
+++ b/build_tester/helpers/ssh.py
@@ -13,9 +13,10 @@ Credentials = namedtuple(
 
 
 class SshClient:
-    def __init__(self, credentials: Credentials, log_func=print):
+    def __init__(self, credentials: Credentials, log_func=print, shell_path='/bin/sh'):
         self.log = log_func
         self.credentials = credentials
+        self.shell_path = shell_path
         self.__ssh = None
         self.__sftp = None
 
@@ -97,7 +98,8 @@ class SshClient:
             channel.settimeout(timeout)
 
             print_logs(in_data=command, log=self.log)
-            channel.exec_command(command)
+            command = command.replace('\\', '\\\\').replace('"', '\\"')
+            channel.exec_command(f'{self.shell_path} -c "{command}"')
             if input_data is not None:
                 channel.send(input_data)
 
@@ -112,7 +114,7 @@ class SshClient:
         good_errors = good_errors or []
 
         for command in commands:
-            output = self.exec_ssh_command(command, timeout)
+            output = self.exec_ssh_command(command, timeout=timeout)
             if output is not None:
                 output_lower = output.lower()
 

--- a/config-example.json
+++ b/config-example.json
@@ -52,27 +52,30 @@
     },
     "os-x": {
       "virtual_box": {
-        "os-x_10.14": {
-          "login": "osx",
-          "password": "osx",
+        "mac-os_10.14": {
+          "login": "checker",
+          "password": "checker",
           "port": 10026,
-          "remote_dir": "/Users/osx/tarantool",
+          "remote_dir": "/Users/checker/tarantool",
+          "shell_path": "/bin/bash",
           "prepare_timeout": 2700,
           "run_timeout": 900
         },
-        "os-x_10.15": {
-          "login": "osx",
-          "password": "osx",
+        "mac-os_10.15": {
+          "login": "checker",
+          "password": "checker",
           "port": 10027,
-          "remote_dir": "/Users/osx/tarantool",
+          "remote_dir": "/Users/checker/tarantool",
+          "shell_path": "/bin/bash",
           "prepare_timeout": 2700,
           "run_timeout": 900
         },
-        "os-x_11.0": {
-          "login": "osx",
-          "password": "osx",
+        "mac-os_11.0": {
+          "login": "checker",
+          "password": "checker",
           "port": 10028,
-          "remote_dir": "/Users/osx/tarantool",
+          "remote_dir": "/Users/checker/tarantool",
+          "shell_path": "/bin/bash",
           "prepare_timeout": 2700,
           "run_timeout": 900
         }

--- a/scripts/prepare/README.md
+++ b/scripts/prepare/README.md
@@ -3,36 +3,78 @@
 Here you can find commands for virtual machines preparation.
 
 Table of contents:
-- [OS X](#OS-X)
-- [FreeBSD](#FreeBSD)
+- [macOS](#macos)
+- [FreeBSD](#freebsd)
 
-## OS X
+## macOS
 
-First, you should create a virtual machine and set its parameters using the
-following commands:
+Open VirtualBox application and make some actions:
+
+1. Create a virtual machine, select `Mac OS X (64-bit)` type,
+   set hard drive size to 64 GB;
+2. Go to "System", disable floppy, select RAM, CPU;
+3. Go to "Display", select Video Memory, enable 3D Acceleration;
+4. Go to "Network", open "Port Forwarding",
+   make routes for `SSH` (port: `22`) and `Tarantool` (port: `3301`).
+
+Set VMs parameters using the following commands:
 
 ```shell
-export OS_X_VM_NAME="os-x_10.14"
+export MAC_OS_VM_NAME="mac-os_11.0"
 
-VBoxManage modifyvm "${OS_X_VM_NAME}" --cpuidset 00000001 000106e5 00100800 0098e3fd bfebfbff
-VBoxManage setextradata "${OS_X_VM_NAME}" "VBoxInternal/Devices/efi/0/Config/DmiSystemProduct" "iMac11,3"
-VBoxManage setextradata "${OS_X_VM_NAME}" "VBoxInternal/Devices/efi/0/Config/DmiSystemVersion" "1.0"
-VBoxManage setextradata "${OS_X_VM_NAME}" "VBoxInternal/Devices/efi/0/Config/DmiBoardProduct" "Iloveapple"
-VBoxManage setextradata "${OS_X_VM_NAME}" "VBoxInternal/Devices/smc/0/Config/DeviceKey" "ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"
-VBoxManage setextradata "${OS_X_VM_NAME}" "VBoxInternal/Devices/smc/0/Config/GetKeyFromRealSMC" 1
-VBoxManage setextradata "${OS_X_VM_NAME}" "VBoxInternal2/EfiHorizontalResolution" 1440
-VBoxManage setextradata "${OS_X_VM_NAME}" "VBoxInternal2/EfiVerticalResolution" 900
+VBoxManage modifyvm "${MAC_OS_VM_NAME}" --cpuidset 00000001 000106e5 00100800 0098e3fd bfebfbff
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "VBoxInternal/Devices/efi/0/Config/DmiSystemProduct" "iMac11,3"
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "VBoxInternal/Devices/efi/0/Config/DmiSystemVersion" "1.0"
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "VBoxInternal/Devices/efi/0/Config/DmiBoardProduct" "Iloveapple"
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "VBoxInternal/Devices/smc/0/Config/DeviceKey" "ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "VBoxInternal/Devices/smc/0/Config/GetKeyFromRealSMC" 1
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "VBoxInternal2/EfiHorizontalResolution" 1440
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "VBoxInternal2/EfiVerticalResolution" 900
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "GUI/Fullscreen" true
+VBoxManage setextradata "${MAC_OS_VM_NAME}" "GUI/ScaleFactor" 2
+```
+
+Download macOS by App Store:
+- [macOS Mojave 10.14](https://apps.apple.com/us/app/macos-mojave/id1398502828)
+- [macOS Catalina 10.15](https://apps.apple.com/us/app/macos-catalina/id1466841314)
+- [macOS Big Sure 11.0](https://apps.apple.com/us/app/macos-big-sur/id1526878132)
+
+Create ISO:
+
+```shell
+export MAC_OS_NAME="Big Sur"
+
+export MAC_OS_SIZE="$(du -sm "/Applications/Install macOS ${MAC_OS_NAME}.app/" | cut -f1)"
+hdiutil create -o "/tmp/${MAC_OS_NAME}" -size "$(expr ${MAC_OS_SIZE} '*' 11 '/' 10)m" -volname "${MAC_OS_NAME}" -layout SPUD -fs HFS+J
+hdiutil attach "/tmp/${MAC_OS_NAME}.dmg" -noverify -mountpoint "/Volumes/${MAC_OS_NAME}"
+sudo "/Applications/Install macOS ${MAC_OS_NAME}.app/Contents/Resources/createinstallmedia" --volume "/Volumes/${MAC_OS_NAME}" --nointeraction
+hdiutil detach -force "/Volumes/Install macOS ${MAC_OS_NAME}"
+hdiutil convert "/tmp/${MAC_OS_NAME}.dmg" -format UDTO -o "${HOME}/Desktop/${MAC_OS_NAME}.cdr"
+rm -f "/tmp/${MAC_OS_NAME}.dmg"
+mv "${HOME}/Desktop/${MAC_OS_NAME}.cdr" "${HOME}/Desktop/${MAC_OS_NAME}.iso"
 ```
 
 Next, you should install the OS, connect to VM and make some actions:
 
-1. go to sharing settings and enable remote login;
-2. go to security settings and enable automatic login, disable screen lock;
-3. go to screen saver and disable it;
-4. go to energy saver and disable all sleeps;
-5. open shell and exec this commands:
+1. go to "Software Update", disable automatic updates, install last updates;
+2. install guest additions;
+3. go to "Sharing" and enable remote login;
+4. go to "Security & Privacy" and enable automatic login, disable screen lock;
+5. go to "Screen Saver" and disable it;
+6. go to "Energy Saver" and disable all sleeps;
+7. open shell and execute this commands:
 
 ```shell
+# Add NOPASSWD option for root user and admin group like here:
+# root ALL=(ALL) NOPASSWD: ALL
+# %admin ALL=(ALL) NOPASSWD: ALL
+sudo visudo
+
+# Add paths to PATH
+cat <<EOF >> .bashrc
+export PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
+EOF
+
 # Install xcode
 git --version
 
@@ -41,16 +83,6 @@ java --version
 
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-
-# Add paths to PATH
-cat <<EOF >> .bashrc
-export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-EOF
-
-# Add NOPASSWD option for root user and admin group like here:
-# root ALL=(ALL) NOPASSWD: ALL
-# %admin ALL=(ALL) NOPASSWD: ALL
-sudo visudo
 ```
 
 ## FreeBSD


### PR DESCRIPTION
Before the path, checker doesn't work for macOS 10.15+.

Changes:
- updated instructions for creating macOS virtual machines;
- add availability to select shell for virtual machines.