### PR TITLE
Enable vault mirror for Centos 8

### DIFF
--- a/scripts/prepare/rhel-centos_8.sh
+++ b/scripts/prepare/rhel-centos_8.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Exit when any command in script file fails
+set -ex
+
+# Preparation commands
+
+# Enable vault mirror because Centos 8 is EOL
+dist=$(grep -Po "[6-9]" /etc/centos-release | head -1)
+if [ $dist = "8" ]; then
+    find /etc/yum.repos.d/ -type f -exec sed -i 's/mirrorlist=/#mirrorlist=/g' {} +
+    find /etc/yum.repos.d/ -type f -exec sed -i 's/#baseurl=/baseurl=/g' {} +
+    find /etc/yum.repos.d/ -type f -exec sed -i 's/mirror.centos.org/vault.centos.org/g' {} +
+fi
+
+# To download and execute tarantool install script
+yum -y upgrade
+yum -y install sudo


### PR DESCRIPTION
Added dedicated prepare script for centos 8

CentOS Linux 8 reached End Of Life on December 31st, 2021. The mirror list
with http://mirrorlist.centos.org/ doesn't work for it. The base URL with
http://mirror.centos.org/ doesn't work as well. So enabling repos from vault
mirrors:
https://github.com/CentOS/sig-cloud-instance-images/issues/190

Script to enable mirror list:
```bash
find /etc/yum.repos.d/ -type f -exec sed -i 's/mirrorlist=/#mirrorlist=/g' {} +
find /etc/yum.repos.d/ -type f -exec sed -i 's/#baseurl=/baseurl=/g' {} +
find /etc/yum.repos.d/ -type f -exec sed -i 's/mirror.centos.org/vault.centos.org/g' {} +
```