### PR TITLE
fix No module named 'six' error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ paramiko~=2.7.2
 pytelegrambotapi~=3.7.9
 peewee~=3.14.4
 emoji~=1.2.0
+six==1.15.0


### PR DESCRIPTION
Added six==1.15.0 to requirements.txt.