### PR TITLE
Specify check parameters with CLI arguments

### DIFF
--- a/build_tester/tester.py
+++ b/build_tester/tester.py
@@ -86,12 +86,16 @@ class Tester:
         builds = []
         for os_name, versions in site_commands.items():
             for build_name, commands in versions.items():
+                if self.config.build and self.config.build not in build_name:
+                    continue
+                if self.config.version and self.config.version not in build_name:
+                    continue
+
                 # Remove os name from build name (ubuntu_manual_2.4 -> manual_2.4)
                 build_name = '_'.join(build_name.split('_')[1:])
 
                 # Save to find not tested
                 self.__all_builds.append((os_name, build_name))
-
                 builds_count = len(builds)
 
                 # This is to avoid running Docker in Docker or Docker in VirtualBox
@@ -125,6 +129,8 @@ class Tester:
                     fs.write('\n')
 
         builds.sort(key=lambda build: f'{self.__get_build_os_name(build)}_{build.build_name}')
+        if self.config.debug_mode:
+            print(builds)
         return builds
 
     def test_builds(self):

--- a/check.py
+++ b/check.py
@@ -23,6 +23,30 @@ def main():
         help='Use this flag to enable debug mode',
     )
     parser.add_argument(
+        '--version',
+        help='Tarantool version, such as 1.10 or 2.10'
+    )
+    parser.add_argument(
+        '--build',
+        help='Tarantool build: manual, script, or nightly',
+    )
+    parser.add_argument(
+        '--dist',
+        help='OS distribution to check, one of '
+             'amazon, '
+             'centos, '
+             'debian, '
+             'fedora, '
+             'freebsd, '
+             'macos, '
+             'opensuse, or '
+             'ubuntu.'
+    )
+    parser.add_argument(
+        '--dist-version',
+        help='Exact version of the distribution to check'
+    )
+    parser.add_argument(
         '--commands-url',
         help='URL for fetching Tarantool build instructions'
     )


### PR DESCRIPTION

`--version` sets the Tarantool version to test, such as 1.10 or 2.10
`--build` sets the Tarantool build, as it appears in the Downloads
  API: script, manual or nightly.
`--dist` -- the OS distribution to test on, such as 'debian'
`--dist-version` -- the exact version of the OS distribution above,
  such as '11' or 'bullseye'

With either of these arguments present, the actual list of checked
distributions is filtered from what's returned by the website's API
and what's found in the JSON config.

For example, API can return the following list for CentOS builds:

- centos_script_2.10
- centos_manual_2.10
- centos_script_1.10
- centos_manual_1.10

With `--version 2.10 --build script`, the Checker will only check
the script build instructions for Tarantool 2.10 on all versions
of CentOS, available in the JSON config, as well as on other
distributions and their version.

Adding `--dist centos --dist-version 7` will narrow the check to CentOS 7 only.

That is, to check the script (default) installation of Tarantool 2.10 on
CentOS 7:

```python
python check.py --version 2.10 --build script --dist centos --dist-version 7
```

Part of #45
