### PR TITLE
readme: added status badge for regular checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-# Delivery Checker
+# Current state
+
+[![Amazon Linux](https://github.com/tarantool/delivery-checker/actions/workflows/amazon.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/amazon.yml)
+[![Amazon Linux @ AArch64](https://github.com/tarantool/delivery-checker/actions/workflows/amazon-aarch64.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/amazon-aarch64.yml)
+[![Debian](https://github.com/tarantool/delivery-checker/actions/workflows/debian.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/debian.yml)
+[![Debian @ AArch64](https://github.com/tarantool/delivery-checker/actions/workflows/debian-aarch64.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/debian-aarch64.yml)
+[![Fedora](https://github.com/tarantool/delivery-checker/actions/workflows/fedora.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/fedora.yml)
+[![Fedora @ AArch64](https://github.com/tarantool/delivery-checker/actions/workflows/fedora-aarch64.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/fedora-aarch64.yml)
+[![RHEL/CentOS](https://github.com/tarantool/delivery-checker/actions/workflows/centos.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/centos.yml)
+[![RHEL/CentOS @ AArch64](https://github.com/tarantool/delivery-checker/actions/workflows/centos-aarch64.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/centos-aarch64.yml)
+[![Ubuntu](https://github.com/tarantool/delivery-checker/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/ubuntu.yml)
+[![Ubuntu @ AArch64](https://github.com/tarantool/delivery-checker/actions/workflows/ubuntu-aarch64.yml/badge.svg)](https://github.com/tarantool/delivery-checker/actions/workflows/ubuntu-aarch64.yml)
+
+# About Delivery Checker
 
 This is a program that downloads Tarantool's installation commands and tries to
 run them on different OS.


### PR DESCRIPTION
Added only stable CI. I don't add badge for OpenSUSE, because we in fact don't check build on OpenSUSE. Also I don't add badges for FreeBSD and MacOS, because successful workflow means only that delivery-checker was successfully deployed, not that we have no problems with FreeBSD and MacOS installation instructions

<img width="1138" alt="Снимок экрана 2022-11-29 в 11 47 39" src="https://user-images.githubusercontent.com/88746790/204482024-34ba2a42-bf3d-470a-874b-060ca0a7549c.png">
