### PR TITLE
ci: change artifacts name

### DIFF
--- a/.github/workflows/amazon-aarch64.yml
+++ b/.github/workflows/amazon-aarch64.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  amazon:
+  amazon-aarch64:
     env:
       dist: 'amazon'
     strategy:
@@ -52,14 +52,10 @@ jobs:
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-amazon-aarch64-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/amazon.yml
+++ b/.github/workflows/amazon.yml
@@ -59,14 +59,10 @@ jobs:
             --build ${{ matrix.build }} \
             -d -v
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-amazon-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/centos-aarch64.yml
+++ b/.github/workflows/centos-aarch64.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  centos:
+  centos-aarch64:
     env:
       dist: 'centos'
     strategy:
@@ -52,14 +52,10 @@ jobs:
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-centos-aarch64-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -59,14 +59,10 @@ jobs:
             --build ${{ matrix.build }} \
             -d -v
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-centos-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/debian-aarch64.yml
+++ b/.github/workflows/debian-aarch64.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  debian:
+  debian-aarch64:
     env:
       dist: 'debian'
     strategy:
@@ -52,14 +52,10 @@ jobs:
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-debian-aarch64-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -59,14 +59,10 @@ jobs:
             --build ${{ matrix.build }} \
             -d -v
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-debian-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/fedora-aarch64.yml
+++ b/.github/workflows/fedora-aarch64.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fedora:
+  fedora-aarch64:
     env:
       dist: 'fedora'
     strategy:
@@ -52,14 +52,10 @@ jobs:
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-fedora-aarch64-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -62,14 +62,10 @@ jobs:
             --build ${{ matrix.build }} \
             -d -v
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-fedora-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -56,14 +56,10 @@ jobs:
             --build brew \
             -d -v
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-osx-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/ubuntu-aarch64.yml
+++ b/.github/workflows/ubuntu-aarch64.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ubuntu:
+  ubuntu-aarch64:
     env:
       dist: 'ubuntu'
     strategy:
@@ -52,14 +52,10 @@ jobs:
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-ubuntu-aarch64-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -63,14 +63,10 @@ jobs:
             --build ${{ matrix.build }} \
             -d -v
 
-      - name: Set current date as env variable
-        if: always()
-        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
-
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ env.NOW }}-ubuntu-${{ github.run_id }}
+          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
           path: archive
 
       - name: Send notification


### PR DESCRIPTION
This patch includes every matrix parameter to the artifact names
to save artifact archive for every matrix job. In this case,
we don't need current time and run ID in artifact name.

Example of artifacts with new naming:
<img width="1768" alt="Снимок экрана 2023-02-07 в 17 06 55" src="https://user-images.githubusercontent.com/88746790/217267251-ae148667-28b9-4aaa-a613-2726bda9da9b.png">
