### PR TITLE
ci: update tarantool version for macOS

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macos-11', 'macos-12' ]
-        tarantool-version: [ '2.10', '2.11' ]
+        tarantool-version: [ '2.10', '3.0' ]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
After release 2.11.0-rc1, `brew install tarantool --HEAD` installs `3.0.0-entrypoint-N-gabcdef123`, not `2.11.0-entrypoint-N-gabcdef123`. This patch updates the version to check. 