### PR TITLE
Check installation of GC64 packages

### DIFF
--- a/.github/workflows/amazon.yml
+++ b/.github/workflows/amazon.yml
@@ -37,7 +37,11 @@ jobs:
       matrix:
         dist-version: [ '2' ]
         tarantool-version: [ '2.10', '1.10' ]
+        pkg-type: [ '', 'gc64' ]
         build: [ 'script' ]
+        exclude:
+          - tarantool-version: '1.10'
+            pkg-type: 'gc64'
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
     steps:
       - uses: actions/checkout@master
@@ -57,7 +61,7 @@ jobs:
             --dist-version ${{ matrix.dist-version }} \
             --version ${{ matrix.tarantool-version }} \
             --build ${{ matrix.build }} \
-            -d -v
+            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
 
       - name: Set current date as env variable
         if: always()

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -37,7 +37,13 @@ jobs:
       matrix:
         dist-version: [ '8', '7' ]
         tarantool-version: [ '2.10', '1.10' ]
+        pkg-type: [ '', 'gc64' ]
         build: [ 'script', 'manual' ]
+        exclude:
+          - tarantool-version: '1.10'
+            pkg-type: 'gc64'
+          - build: 'manual'
+            pkg-type: 'gc64'
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
     steps:
       - uses: actions/checkout@master
@@ -57,7 +63,7 @@ jobs:
             --dist-version ${{ matrix.dist-version }} \
             --version ${{ matrix.tarantool-version }} \
             --build ${{ matrix.build }} \
-            -d -v
+            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
 
       - name: Set current date as env variable
         if: always()

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -37,7 +37,13 @@ jobs:
       matrix:
         dist-version: [ '11', '10', '9' ]
         tarantool-version: [ '2.10', '1.10' ]
+        pkg-type: [ '', 'gc64' ]
         build: [ 'script', 'manual' ]
+        exclude:
+          - tarantool-version: '1.10'
+            pkg-type: 'gc64'
+          - build: 'manual'
+            pkg-type: 'gc64'
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
     steps:
       - uses: actions/checkout@master
@@ -57,7 +63,7 @@ jobs:
             --dist-version ${{ matrix.dist-version }} \
             --version ${{ matrix.tarantool-version }} \
             --build ${{ matrix.build }} \
-            -d -v
+            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
 
       - name: Set current date as env variable
         if: always()

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -37,10 +37,13 @@ jobs:
       matrix:
         dist-version: [ '36', '35', '34' ]
         tarantool-version: [ '2.10', '1.10' ]
+        pkg-type: [ '', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
           - tarantool-version: '1.10'
-            dist-version: '36'
+            pkg-type: 'gc64'
+          - build: 'manual'
+            pkg-type: 'gc64'
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
     steps:
       - uses: actions/checkout@master
@@ -60,7 +63,7 @@ jobs:
             --dist-version ${{ matrix.dist-version }} \
             --version ${{ matrix.tarantool-version }} \
             --build ${{ matrix.build }} \
-            -d -v
+            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
 
       - name: Set current date as env variable
         if: always()

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,10 +37,13 @@ jobs:
       matrix:
         dist-version: [ '22.04', '20.04', '18.04', '16.04' ]
         tarantool-version: [ '2.10', '1.10' ]
+        pkg-type: [ '', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
           - tarantool-version: '1.10'
-            dist-version: '22.04'
+            pkg-type: 'gc64'
+          - build: 'manual'
+            pkg-type: 'gc64'
 
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
     steps:
@@ -61,7 +64,7 @@ jobs:
             --dist-version ${{ matrix.dist-version }} \
             --version ${{ matrix.tarantool-version }} \
             --build ${{ matrix.build }} \
-            -d -v
+            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
 
       - name: Set current date as env variable
         if: always()

--- a/build_tester/builders/docker_builder.py
+++ b/build_tester/builders/docker_builder.py
@@ -165,6 +165,12 @@ class DockerBuilder:
         result = False
 
         try:
+            if self.build_info.build_name.endswith('_gc64'):
+                tnt_version = self.build_info.build_name.split('_')[-2]
+                gc64 = 'true'
+            else:
+                tnt_version = self.build_info.build_name.split('_')[-1]
+                gc64 = 'false'
             self.__image_id = self.__build_image(
                 path=self.scripts_dir_path,
                 tag=container_name,
@@ -174,7 +180,8 @@ class DockerBuilder:
                     'OS_NAME': self.build_info.os_name,
                     'PREPARE_SCRIPT_NAME': self.__get_best_prepare_script(),
                     'BUILD_NAME': self.build_info.build_name,
-                    'TNT_VERSION': self.build_info.build_name.split("_")[-1],
+                    'TNT_VERSION': tnt_version,
+                    'GC64': gc64,
                 },
                 timeout=timeout,
                 nocache=not self.build_info.use_cache,

--- a/build_tester/tester.py
+++ b/build_tester/tester.py
@@ -110,6 +110,10 @@ class Tester:
                 # Remove os name from build name (ubuntu_manual_2.4 -> manual_2.4)
                 build_name = '_'.join(build_name.split('_')[1:])
 
+                # Add 'gc64' suffix to build name
+                if self.config.gc64:
+                    build_name += '_gc64'
+
                 # Save to find not tested
                 self.__all_builds.append((os_name, build_name))
                 builds_count = len(builds)

--- a/check.py
+++ b/check.py
@@ -32,6 +32,11 @@ def main():
         help='Tarantool version, such as 1.10 or 2.10'
     )
     parser.add_argument(
+        '--gc64',
+        action='store_true',
+        help='Check installation of GC64 packages'
+    )
+    parser.add_argument(
         '--build',
         help='Tarantool build: manual, script, or nightly',
     )

--- a/config/config.py
+++ b/config/config.py
@@ -54,6 +54,7 @@ class CheckerConfig:
     """
     # Parameters to choose the exact installation instruction
     version: str  # Tarantool version from CLI args, such as 1.10 or 2.10
+    gc64: bool  # Check installation of GC64 packages
     build: str  # A build type from CLI args: script or manual
     dist: str  # OS for check from CLI args (for docker or VM) or from the host
     dist_version: str  # OS version from CLI args (for docker or VM) or from the host
@@ -98,8 +99,15 @@ class CheckerConfig:
     def __init__(self, cli_args, config_json=None):
 
         self.version = cli_args.version or None
+        self.gc64 = cli_args.gc64 or False
         self.build = cli_args.build or None
         self.host_mode = cli_args.host_mode or False
+
+        if self.gc64 and self.build == 'manual':
+            raise NotImplementedError(
+                'Manual instruction for the installation of GC64 packages is not implemented '
+                'on the site'
+            )
 
         if self.host_mode:
             self.dist, self.dist_version = get_host_os_info()

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -18,6 +18,7 @@ RUN ./prepare.sh
 
 ARG BUILD_NAME="latest"
 ARG TNT_VERSION
+ARG GC64
 
 COPY install/${OS_NAME}_${BUILD_NAME}.sh install.sh
 RUN chmod +x install.sh
@@ -27,6 +28,7 @@ ARG VERSION
 ENV RESULTS_DIR="${WORK_DIR}/results"
 ENV RESULTS_FILE="${RESULTS_DIR}/${OS_NAME}_${VERSION}_${BUILD_NAME}.json"
 ENV TNT_VERSION="${TNT_VERSION}"
+ENV GC64="${GC64}"
 
 RUN mkdir -p ${RESULTS_DIR}
 

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -19,7 +19,7 @@ local function write_results(results)
         res_filename = 'tests_results.json'
     end
     local res_fh = fio.open(res_filename, { 'O_CREAT', 'O_TRUNC', 'O_WRONLY' }, tonumber('644', 8))
-    res_fh:write(json.encode(results))
+    res_fh:write(json.encode(results) .. '\n')
     res_fh:close()
 end
 
@@ -41,8 +41,20 @@ local function tnt_version()
     assert(begin == 1, 'Expected version: ' .. expected_version .. ', got: ' .. _TARANTOOL)
 end
 
+local function gc64()
+    local gc64_actual = tostring(require('ffi').abi('gc64'))
+    local gc64_expected = os.getenv('GC64') or 'false'
+    assert(gc64_actual == gc64_expected,
+        'Expected GC64: ' .. gc64_expected .. ', got: ' .. gc64_actual)
+end
+
 local results = {}
 results['tnt_version'] = test(tnt_version)
+if os.execute('[ $(uname) = Linux ]') == 0 then
+    if os.execute('[ $(uname -m) = x86_64 ]') == 0 then
+        results['gc64'] = test(gc64)
+    end
+end
 results['box_cfg'] = test(box_cfg)
 write_results(results)
 


### PR DESCRIPTION
Check the installation of GC64 packages for the x86_64 platform, for
which we have separate repositories with such packages.

There is no need to test the installation of GC64 packages for the
aarch64 platform. All packages for this platform are GC64 ones by
default. That's why we don't even have separate repositories for them.

Note, for now we cannot test the manual instruction for the installation
of GC64 packages because it is not implemented on the site.

Closes #39