### PR TITLE
Dirty workaround to use custom Docker image

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Run check.py script
       run: |
-        source ./venv/bin/activate && python check.py --config config-example.json \
+        source ./venv/bin/activate && python check.py --config config-ci.json \
           --dist ${{ inputs.dist }} \
           --dist-version ${{ inputs.dist-version }} \
           --version ${{ inputs.tarantool-version }} \

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -1,31 +1,46 @@
 ---
-name: 'Check Tarantool installation'
+name: Check Tarantool installation
 description: >
-  'Check if Tarantool version installs on a given
-  distribution/version with specified build type'
+  Check if Tarantool version installs on a given distribution/version with
+  specified build type
+
 inputs:
   dist:
-    description: 'Distribution name'
+    description: Distribution name
     required: true
   dist-version:
-    description: 'Distribution version'
+    description: Distribution version
     required: true
   tarantool-version:
-    description: 'Tarantool version'
+    description: Tarantool version
     required: true
   build:
     description: 'Build or installation method: script, manual or nightly'
     required: true
+  pkg-type:
+    description: >
+      Type of package to be installed. Provide 'gc64' to install GC64 package
+    required: false
+
 runs:
-  using: "composite"
+  using: composite
   steps:
-    # Setup Python environment
-    - shell: bash
+    - name: Setup Python environment
+      uses: tarantool/actions/setup-venv@master
+
+    - name: Run check.py script
       run: |
-        source ./venv/bin/activate && \
-        python check.py --config config-example.json \
+        source ./venv/bin/activate && python check.py --config config-example.json \
           --dist ${{ inputs.dist }} \
           --dist-version ${{ inputs.dist-version }} \
           --version ${{ inputs.tarantool-version }} \
           --build ${{ inputs.build }} \
-          -d -v
+          -d -v ${{ inputs.pkg-type == 'gc64' && '--gc64' || '' }}
+      shell: bash
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}-${{ join(matrix.*, '-') }}
+        path: archive

--- a/.github/workflows/amazon-aarch64.yml
+++ b/.github/workflows/amazon-aarch64.yml
@@ -33,32 +33,29 @@ jobs:
   amazon-aarch64:
     env:
       dist: 'amazon'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '2' ]
         tarantool-version: [ '2.10' ]
         build: [ 'script' ]
+
     runs-on: [ self-hosted, graviton ]
+
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: tarantool/actions/setup-venv@master
-
-      - uses: ./.github/actions/check
+      - name: Check installation of Tarantool
+        uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
           dist-version: ${{ matrix.dist-version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
-
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/amazon.yml
+++ b/.github/workflows/amazon.yml
@@ -32,44 +32,34 @@ jobs:
   amazon:
     env:
       dist: 'amazon'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '2' ]
         tarantool-version: [ '2.10', '1.10' ]
-        pkg-type: [ '', 'gc64' ]
+        pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script' ]
         exclude:
           - tarantool-version: '1.10'
             pkg-type: 'gc64'
-    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
-    steps:
-      - uses: actions/checkout@master
 
-      - name: Setup Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8.5'
-          cache: pip
-      - name: Setup Python requirements
-        run: pip install -r requirements.txt
+    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
       - name: Check installation of Tarantool
-        run: |
-          python check.py --config config-example.json \
-            --dist ${{ env.dist }} \
-            --dist-version ${{ matrix.dist-version }} \
-            --version ${{ matrix.tarantool-version }} \
-            --build ${{ matrix.build }} \
-            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
-
-      - uses: actions/upload-artifact@v3
-        if: always()
+        uses: ./.github/actions/check
         with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
+          dist: ${{ env.dist }}
+          dist-version: ${{ matrix.dist-version }}
+          tarantool-version: ${{ matrix.tarantool-version }}
+          build: ${{ matrix.build }}
+          pkg-type: ${{ matrix.pkg-type }}
 
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/centos-aarch64.yml
+++ b/.github/workflows/centos-aarch64.yml
@@ -33,32 +33,29 @@ jobs:
   centos-aarch64:
     env:
       dist: 'centos'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '8', '7' ]
         tarantool-version: [ '2.10' ]
         build: [ 'script', 'manual' ]
+
     runs-on: [ self-hosted, graviton ]
+
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: tarantool/actions/setup-venv@master
-
-      - uses: ./.github/actions/check
+      - name: Check installation of Tarantool
+        uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
           dist-version: ${{ matrix.dist-version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
-
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -32,46 +32,36 @@ jobs:
   centos:
     env:
       dist: 'centos'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '8', '7' ]
         tarantool-version: [ '2.10', '1.10' ]
-        pkg-type: [ '', 'gc64' ]
+        pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
           - tarantool-version: '1.10'
             pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
-    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
-    steps:
-      - uses: actions/checkout@master
 
-      - name: Setup Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8.5'
-          cache: pip
-      - name: Setup Python requirements
-        run: pip install -r requirements.txt
+    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
       - name: Check installation of Tarantool
-        run: |
-          python check.py --config config-example.json \
-            --dist ${{ env.dist }} \
-            --dist-version ${{ matrix.dist-version }} \
-            --version ${{ matrix.tarantool-version }} \
-            --build ${{ matrix.build }} \
-            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
-
-      - uses: actions/upload-artifact@v3
-        if: always()
+        uses: ./.github/actions/check
         with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
+          dist: ${{ env.dist }}
+          dist-version: ${{ matrix.dist-version }}
+          tarantool-version: ${{ matrix.tarantool-version }}
+          build: ${{ matrix.build }}
+          pkg-type: ${{ matrix.pkg-type }}
 
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/debian-aarch64.yml
+++ b/.github/workflows/debian-aarch64.yml
@@ -33,32 +33,29 @@ jobs:
   debian-aarch64:
     env:
       dist: 'debian'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '11', '10' ]
         tarantool-version: [ '2.10' ]
         build: [ 'script', 'manual' ]
+
     runs-on: [ self-hosted, graviton ]
+
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: tarantool/actions/setup-venv@master
-
-      - uses: ./.github/actions/check
+      - name: Check installation of Tarantool
+        uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
           dist-version: ${{ matrix.dist-version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
-
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -52,11 +52,19 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Change Docker image if needed
+        run: |
+          version="${{ matrix.dist-version }}"
+          if ${{ matrix.dist-version == '9' }}; then
+            version="tarantool/delivery-checker:debian-stretch"
+          fi
+          echo "version=${version}" >> $GITHUB_ENV
+
       - name: Check installation of Tarantool
         uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
-          dist-version: ${{ matrix.dist-version }}
+          dist-version: ${{ env.version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
           pkg-type: ${{ matrix.pkg-type }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -32,46 +32,36 @@ jobs:
   debian:
     env:
       dist: 'debian'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '11', '10', '9' ]
         tarantool-version: [ '2.10', '1.10' ]
-        pkg-type: [ '', 'gc64' ]
+        pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
           - tarantool-version: '1.10'
             pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
-    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
-    steps:
-      - uses: actions/checkout@master
 
-      - name: Setup Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8.5'
-          cache: pip
-      - name: Setup Python requirements
-        run: pip install -r requirements.txt
+    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
       - name: Check installation of Tarantool
-        run: |
-          python check.py --config config-example.json \
-            --dist ${{ env.dist }} \
-            --dist-version ${{ matrix.dist-version }} \
-            --version ${{ matrix.tarantool-version }} \
-            --build ${{ matrix.build }} \
-            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
-
-      - uses: actions/upload-artifact@v3
-        if: always()
+        uses: ./.github/actions/check
         with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
+          dist: ${{ env.dist }}
+          dist-version: ${{ matrix.dist-version }}
+          tarantool-version: ${{ matrix.tarantool-version }}
+          build: ${{ matrix.build }}
+          pkg-type: ${{ matrix.pkg-type }}
 
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/fedora-aarch64.yml
+++ b/.github/workflows/fedora-aarch64.yml
@@ -47,11 +47,19 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Change Docker image if needed
+        run: |
+          version="${{ matrix.dist-version }}"
+          if ${{ contains('34, 35', matrix.dist-version) }}; then
+            version="tarantool/delivery-checker:fedora-${{ matrix.dist-version }}"
+          fi
+          echo "version=${version}" >> $GITHUB_ENV
+
       - name: Check installation of Tarantool
         uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
-          dist-version: ${{ matrix.dist-version }}
+          dist-version: ${{ env.version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 

--- a/.github/workflows/fedora-aarch64.yml
+++ b/.github/workflows/fedora-aarch64.yml
@@ -33,32 +33,29 @@ jobs:
   fedora-aarch64:
     env:
       dist: 'fedora'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '36', '35', '34' ]
         tarantool-version: [ '2.10' ]
         build: [ 'script', 'manual' ]
+
     runs-on: [ self-hosted, graviton ]
+
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: tarantool/actions/setup-venv@master
-
-      - uses: ./.github/actions/check
+      - name: Check installation of Tarantool
+        uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
           dist-version: ${{ matrix.dist-version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
-
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -52,11 +52,19 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Change Docker image if needed
+        run: |
+          version="${{ matrix.dist-version }}"
+          if ${{ contains('34, 35', matrix.dist-version) }}; then
+            version="tarantool/delivery-checker:fedora-${{ matrix.dist-version }}"
+          fi
+          echo "version=${version}" >> $GITHUB_ENV
+
       - name: Check installation of Tarantool
         uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
-          dist-version: ${{ matrix.dist-version }}
+          dist-version: ${{ env.version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
           pkg-type: ${{ matrix.pkg-type }}

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -32,46 +32,36 @@ jobs:
   fedora:
     env:
       dist: 'fedora'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '36', '35', '34' ]
         tarantool-version: [ '2.10', '1.10' ]
-        pkg-type: [ '', 'gc64' ]
+        pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
           - tarantool-version: '1.10'
             pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
-    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
-    steps:
-      - uses: actions/checkout@master
 
-      - name: Setup Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8.5'
-          cache: pip
-      - name: Setup Python requirements
-        run: pip install -r requirements.txt
+    runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
       - name: Check installation of Tarantool
-        run: |
-          python check.py --config config-example.json \
-            --dist ${{ env.dist }} \
-            --dist-version ${{ matrix.dist-version }} \
-            --version ${{ matrix.tarantool-version }} \
-            --build ${{ matrix.build }} \
-            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
-
-      - uses: actions/upload-artifact@v3
-        if: always()
+        uses: ./.github/actions/check
         with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
+          dist: ${{ env.dist }}
+          dist-version: ${{ matrix.dist-version }}
+          tarantool-version: ${{ matrix.tarantool-version }}
+          build: ${{ matrix.build }}
+          pkg-type: ${{ matrix.pkg-type }}
 
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/ubuntu-aarch64.yml
+++ b/.github/workflows/ubuntu-aarch64.yml
@@ -33,32 +33,29 @@ jobs:
   ubuntu-aarch64:
     env:
       dist: 'ubuntu'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '22.04', '20.04' ]
         tarantool-version: [ '2.10']
         build: [ 'script', 'manual' ]
+
     runs-on: [ self-hosted, graviton ]
+
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - uses: tarantool/actions/setup-venv@master
-
-      - uses: ./.github/actions/check
+      - name: Check installation of Tarantool
+        uses: ./.github/actions/check
         with:
           dist: ${{ env.dist }}
           dist-version: ${{ matrix.dist-version }}
           tarantool-version: ${{ matrix.tarantool-version }}
           build: ${{ matrix.build }}
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
-
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,12 +32,13 @@ jobs:
   ubuntu:
     env:
       dist: 'ubuntu'
+
     strategy:
       fail-fast: false
       matrix:
         dist-version: [ '22.04', '20.04', '18.04', '16.04' ]
         tarantool-version: [ '2.10', '1.10' ]
-        pkg-type: [ '', 'gc64' ]
+        pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
           - tarantool-version: '1.10'
@@ -46,33 +47,21 @@ jobs:
             pkg-type: 'gc64'
 
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
-    steps:
-      - uses: actions/checkout@master
 
-      - name: Setup Python environment
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8.5'
-          cache: pip
-      - name: Setup Python requirements
-        run: pip install -r requirements.txt
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
       - name: Check installation of Tarantool
-        run: |
-          python check.py --config config-example.json \
-            --dist ${{ env.dist }} \
-            --dist-version ${{ matrix.dist-version }} \
-            --version ${{ matrix.tarantool-version }} \
-            --build ${{ matrix.build }} \
-            -d -v ${{ matrix.pkg-type == 'gc64' && '--gc64' || '' }}
-
-      - uses: actions/upload-artifact@v3
-        if: always()
+        uses: ./.github/actions/check
         with:
-          name: ${{ github.job }}-${{ Join(matrix.*, '-') }}
-          path: archive
+          dist: ${{ env.dist }}
+          dist-version: ${{ matrix.dist-version }}
+          tarantool-version: ${{ matrix.tarantool-version }}
+          build: ${{ matrix.build }}
+          pkg-type: ${{ matrix.pkg-type }}
 
-      - name: Send notification
+      - name: Send notification on failure
         if: failure()
         uses: ./.github/actions/failure-notify
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ remote/
 archive/
 config*.json
 !config-example.json
+!config-ci.json
 !config-full.json
 !config-current.json
 *.db

--- a/build_tester/builders/docker_builder.py
+++ b/build_tester/builders/docker_builder.py
@@ -46,11 +46,13 @@ class DockerBuilder:
                 for tnt_version in params["skip_os_versions"].get(version, []):
                     if build_name.endswith(tnt_version):
                         skip = True
-
+            image = params.get('image', os_name)
+            if 'tarantool/delivery-checker:' in version:
+                image, version = version.partition(':')[::2]
             build_list.append(DockerInfo(
                 os_name=os_name,
                 build_name=build_name,
-                image=params.get('image', os_name),
+                image=image,
                 image_version=version,
                 skip=build_name in params.get('skip', []) or skip,
                 use_cache=params.get('use_cache', default_use_cache),

--- a/config-ci.json
+++ b/config-ci.json
@@ -1,0 +1,49 @@
+{
+  "os_params": {
+    "amazon-linux": {
+      "docker": {
+        "image": "amazonlinux",
+        "versions": [
+          "2"
+        ]
+      }
+    },
+    "debian": {
+      "docker": {
+        "versions": [
+          "tarantool/delivery-checker:debian-stretch",
+          "buster",
+          "bullseye"
+        ]
+      }
+    },
+    "fedora": {
+      "docker": {
+        "versions": [
+          "tarantool/delivery-checker:fedora-34",
+          "tarantool/delivery-checker:fedora-35",
+          "36"
+        ]
+      }
+    },
+    "rhel-centos": {
+      "docker": {
+        "image": "centos",
+        "versions": [
+          "7",
+          "8"
+        ]
+      }
+    },
+    "ubuntu": {
+      "docker": {
+        "versions": [
+          "16.04",
+          "18.04",
+          "20.04",
+          "22.04"
+        ]
+      }
+    }
+  }
+}

--- a/custom/docker/debian/stretch/Dockerfile
+++ b/custom/docker/debian/stretch/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:stretch
+
+# The support for Debian Stretch ended on June 30, 2022.
+# The package repository has been moved to http://archive.debian.org.
+ADD sources.list /etc/apt/
+RUN echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/00nocheckvalid

--- a/custom/docker/debian/stretch/sources.list
+++ b/custom/docker/debian/stretch/sources.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian stretch main
+deb http://archive.debian.org/debian-security stretch/updates main

--- a/custom/docker/fedora/34/Dockerfile
+++ b/custom/docker/fedora/34/Dockerfile
@@ -1,0 +1,8 @@
+ARG ARCH=
+FROM ${ARCH}fedora:34
+
+# The support for Fedora Linux ended on June 7, 2022.
+# The package repository has been moved to http://archives.fedoraproject.org.
+RUN sed -i 's/metalink=/#metalink=/g' /etc/yum.repos.d/*
+RUN sed -i 's/#baseurl=/baseurl=/g' /etc/yum.repos.d/*
+RUN sed -i 's/download.example\/pub/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/*

--- a/custom/docker/fedora/35/Dockerfile
+++ b/custom/docker/fedora/35/Dockerfile
@@ -1,0 +1,8 @@
+ARG ARCH=
+FROM ${ARCH}fedora:35
+
+# The support for Fedora Linux ended on December 13, 2022.
+# The package repository has been moved to http://archives.fedoraproject.org.
+RUN sed -i 's/metalink=/#metalink=/g' /etc/yum.repos.d/*
+RUN sed -i 's/#baseurl=/baseurl=/g' /etc/yum.repos.d/*
+RUN sed -i 's/download.example\/pub/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/*


### PR DESCRIPTION
**Dirty workaround to use custom Docker images**

Add a dirty workaround to be able to use a custom Docker image for
checking Tarantool installation. In the future, we should rework the
relevant part of the project and do the same in more elegant way.

---

**Add custom Docker files for EOL distros**

Affected distros:

- Debian 9
- Fedora 34
- Fedora 35

The corresponding Docker images were built from these files and pushed
to the `tarantool/delivery-checker` repository.

---

**Refactor GitHub Linux workflows**

Extract the common part for all Linux workflows into the local
`.github/actions/check` action.

---

**Use custom Docker image for Debian 9, Fedora 34/35**

Use custom Docker image for Debian 9 and Fedora 34/35 since it is
impossible to install software in the corresponding vanilla image.