### PR TITLE
ci: bump tarantool version from 2.10 to 2.11

### DIFF
--- a/.github/workflows/amazon-aarch64.yml
+++ b/.github/workflows/amazon-aarch64.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '2' ]
-        tarantool-version: [ '2.10' ]
+        tarantool-version: [ '2.11' ]
         build: [ 'script' ]
 
     runs-on: [ self-hosted, graviton ]

--- a/.github/workflows/amazon.yml
+++ b/.github/workflows/amazon.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '2' ]
-        tarantool-version: [ '2.10', '1.10' ]
+        tarantool-version: [ '2.11', '1.10' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script' ]
         exclude:

--- a/.github/workflows/centos-aarch64.yml
+++ b/.github/workflows/centos-aarch64.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '8', '7' ]
-        tarantool-version: [ '2.10' ]
+        tarantool-version: [ '2.11' ]
         build: [ 'script', 'manual' ]
 
     runs-on: [ self-hosted, graviton ]

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '8', '7' ]
-        tarantool-version: [ '2.10', '1.10' ]
+        tarantool-version: [ '2.11', '1.10' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:

--- a/.github/workflows/debian-aarch64.yml
+++ b/.github/workflows/debian-aarch64.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '11', '10' ]
-        tarantool-version: [ '2.10' ]
+        tarantool-version: [ '2.11' ]
         build: [ 'script', 'manual' ]
 
     runs-on: [ self-hosted, graviton ]

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '11', '10', '9' ]
-        tarantool-version: [ '2.10', '1.10' ]
+        tarantool-version: [ '2.11', '1.10' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:

--- a/.github/workflows/fedora-aarch64.yml
+++ b/.github/workflows/fedora-aarch64.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '36', '35', '34' ]
-        tarantool-version: [ '2.10' ]
+        tarantool-version: [ '2.11' ]
         build: [ 'script', 'manual' ]
 
     runs-on: [ self-hosted, graviton ]

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '36', '35', '34' ]
-        tarantool-version: [ '2.10', '1.10' ]
+        tarantool-version: [ '2.11', '1.10' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:

--- a/.github/workflows/ubuntu-aarch64.yml
+++ b/.github/workflows/ubuntu-aarch64.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '22.04', '20.04' ]
-        tarantool-version: [ '2.10']
+        tarantool-version: [ '2.11']
         build: [ 'script', 'manual' ]
 
     runs-on: [ self-hosted, graviton ]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '22.04', '20.04', '18.04', '16.04' ]
-        tarantool-version: [ '2.10', '1.10' ]
+        tarantool-version: [ '2.11', '1.10' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:


### PR DESCRIPTION
Tarantool 2.11.0 has been released recently, and it's time to check 2.11 in favour of 2.10.