### PR TITLE
ci: bump tarantool version from 2.10 to 2.11 (macOS)

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-11', 'macos-12' ]
+        os: [ 'macos-12', 'macos-13' ]
         tarantool-version: [ '2.11', '3.0' ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macos-11', 'macos-12' ]
-        tarantool-version: [ '2.10', '3.0' ]
+        tarantool-version: [ '2.11', '3.0' ]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Setup Python requirements
         run: pip install -r requirements.txt
 
+      - name: Fetch newest version of Homebrew and all formulae
+        run: brew update --auto-update
+
       - name: Check installation of Tarantool
         run: |
           python check.py --host-mode \

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -38,7 +38,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Setup Python environment
         uses: actions/setup-python@v4


### PR DESCRIPTION
Bump 2.10 EOL to 2.11 LTS after Tarantool 2.11 release [1].

[1] https://github.com/tarantool/tarantool/releases/tag/2.11.0