### PR TITLE
ci: added checks for tarantool 3.0

### DIFF
--- a/.github/workflows/centos-aarch64.yml
+++ b/.github/workflows/centos-aarch64.yml
@@ -40,6 +40,10 @@ jobs:
         dist-version: [ '8', '7' ]
         tarantool-version: [ '2.11' ]
         build: [ 'script', 'manual' ]
+        include:
+          - dist-version: '8'
+            tarantool-version: '3.0'
+            build: 'script'
 
     runs-on: [ self-hosted, graviton ]
 

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -45,6 +45,11 @@ jobs:
             pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
+        include:
+          - dist-version: '8'
+            tarantool-version: '3.0'
+            pkg-type: 'gc64'
+            build: 'script'
 
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
 

--- a/.github/workflows/ubuntu-aarch64.yml
+++ b/.github/workflows/ubuntu-aarch64.yml
@@ -40,6 +40,10 @@ jobs:
         dist-version: [ '22.04', '20.04' ]
         tarantool-version: [ '2.11']
         build: [ 'script', 'manual' ]
+        include:
+          - dist-version: '22.04'
+            tarantool-version: '3.0'
+            build: 'script'
 
     runs-on: [ self-hosted, graviton ]
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -45,6 +45,11 @@ jobs:
             pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
+        include:
+          - dist-version: '22.04'
+            tarantool-version: '3.0'
+            pkg-type: 'gc64'
+            build: 'script'
 
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
 


### PR DESCRIPTION
Added matrix to check tarantool 3.0 script installation. Because in the 3.0 version we use static build, we don't need to check it on every distro, so we use one rpm-based (CentOS 7) and one deb-based (Ubuntu 22.04) on x86_64 and aarch64 architectures.