### PR TITLE
ci: check rocks' server is operational

### DIFF
--- a/.github/workflows/rocks-server.yml
+++ b/.github/workflows/rocks-server.yml
@@ -1,0 +1,63 @@
+name: Rocks server
+on:
+  schedule:
+    # Run every hour.
+    - cron: '0 */1 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/rocks-server.yml'
+
+# Cancel workflow runs on PRs when the PR is updated with a newer commit.
+# Such runs will have a concurrency group named
+# `{github.workflow}-{github.ref}`,
+# for example,
+# `Amazon Linux-refs/pull/42/merge`.
+#
+# Runs on branch `master` and tags will never be canceled,
+# due to having a unique group name
+# `{github.run_id}-{github.run_attempt}`,
+# for example,
+# `3477882280-1`.
+concurrency:
+  group: ${{
+    (
+    github.ref == 'refs/heads/master' ||
+    startsWith(github.ref, 'refs/tags/')
+    ) &&
+    format('{0}-{1}', github.run_id, github.run_attempt) ||
+    format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+env:
+  ROCK: vshard
+  ROCK_VERSION: 0.1.26
+
+jobs:
+  check-rocks-server:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Install repo for tarantool and its modules
+        run: curl -L https://tarantool.io/release/3/installer.sh | bash
+
+      - name: Install tarantool, tarantool-dev, tt
+        run: sudo apt-get -y install tarantool tarantool-dev tt
+
+      - name: Install rocks
+        run: tt rocks install ${{ env.ROCK }} ${{ env.ROCK_VERSION }}
+
+      - name: Check the rock is intalled
+        run: tt rocks show ${{ env.ROCK }}
+
+      - name: Checkout repo for access to failure-notify action
+        if: failure()
+        uses: actions/checkout@v4
+
+      - name: Send notification on failure
+        if: failure()
+        uses: ./.github/actions/failure-notify
+        with:
+          bot-token: ${{ secrets.VKTEAMS_TARANTOOLBOT_TOKEN }}
+          service-chat-id: ${{ secrets.VKTEAMS_SERVICE_CHAT_ID }}
+          debug-chat-id: ${{ secrets.VKTEAMS_DEBUG_CHAT_ID }}


### PR DESCRIPTION
This patch adds the workflow to install the `vshard` rock via `tt` every hour to check if the rocks' server is operational.

Resolves #56