### PR TITLE
ci: remove checks for `1.10`

### DIFF
--- a/.github/workflows/amazon.yml
+++ b/.github/workflows/amazon.yml
@@ -37,12 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '2' ]
-        tarantool-version: [ '2.11', '1.10' ]
+        tarantool-version: [ '2.11' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script' ]
-        exclude:
-          - tarantool-version: '1.10'
-            pkg-type: 'gc64'
 
     runs-on: [ self-hosted, ubuntu-20.04-self-hosted ]
 

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -37,12 +37,10 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '8', '7' ]
-        tarantool-version: [ '2.11', '1.10' ]
+        tarantool-version: [ '2.11' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
-          - tarantool-version: '1.10'
-            pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
         include:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -37,12 +37,10 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '11', '10', '9' ]
-        tarantool-version: [ '2.11', '1.10' ]
+        tarantool-version: [ '2.11' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
-          - tarantool-version: '1.10'
-            pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
 

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -37,12 +37,10 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '36', '35', '34' ]
-        tarantool-version: [ '2.11', '1.10' ]
+        tarantool-version: [ '2.11' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
-          - tarantool-version: '1.10'
-            pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
 

--- a/.github/workflows/ubuntu-aarch64.yml
+++ b/.github/workflows/ubuntu-aarch64.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '22.04', '20.04' ]
-        tarantool-version: [ '2.11']
+        tarantool-version: [ '2.11' ]
         build: [ 'script', 'manual' ]
         include:
           - dist-version: '22.04'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,12 +37,10 @@ jobs:
       fail-fast: false
       matrix:
         dist-version: [ '22.04', '20.04', '18.04', '16.04' ]
-        tarantool-version: [ '2.11', '1.10' ]
+        tarantool-version: [ '2.11' ]
         pkg-type: [ 'nogc64', 'gc64' ]
         build: [ 'script', 'manual' ]
         exclude:
-          - tarantool-version: '1.10'
-            pkg-type: 'gc64'
           - build: 'manual'
             pkg-type: 'gc64'
         include:

--- a/check.py
+++ b/check.py
@@ -29,7 +29,7 @@ def main():
     )
     parser.add_argument(
         '--version',
-        help='Tarantool version, such as 1.10 or 2.10'
+        help='Tarantool version, such as 2.11 or 3.0'
     )
     parser.add_argument(
         '--gc64',

--- a/config/config.py
+++ b/config/config.py
@@ -53,7 +53,7 @@ class CheckerConfig:
     3. Default values.
     """
     # Parameters to choose the exact installation instruction
-    version: str  # Tarantool version from CLI args, such as 1.10 or 2.10
+    version: str  # Tarantool version from CLI args, such as 2.11 or 3.0
     gc64: bool  # Check installation of GC64 packages
     build: str  # A build type from CLI args: script or manual
     dist: str  # OS for check from CLI args (for docker or VM) or from the host


### PR DESCRIPTION
Remove Tarantool installation instructions for version `1.10` due to [ending EOS period](https://www.tarantool.io/en/doc/latest/release/eol_versions/) (February, 2024).