### PR TITLE
ci: bump tarantool version from 3.0 to 3.1

### DIFF
--- a/.github/workflows/amazon-aarch64.yml
+++ b/.github/workflows/amazon-aarch64.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check installation of Tarantool
         uses: ./.github/actions/check

--- a/.github/workflows/amazon.yml
+++ b/.github/workflows/amazon.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check installation of Tarantool
         uses: ./.github/actions/check

--- a/.github/workflows/centos-aarch64.yml
+++ b/.github/workflows/centos-aarch64.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check installation of Tarantool
         uses: ./.github/actions/check

--- a/.github/workflows/centos-aarch64.yml
+++ b/.github/workflows/centos-aarch64.yml
@@ -42,7 +42,7 @@ jobs:
         build: [ 'script', 'manual' ]
         include:
           - dist-version: '8'
-            tarantool-version: '3.0'
+            tarantool-version: '3.1'
             build: 'script'
 
     runs-on: [ self-hosted, graviton ]

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check installation of Tarantool
         uses: ./.github/actions/check

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -45,7 +45,7 @@ jobs:
             pkg-type: 'gc64'
         include:
           - dist-version: '8'
-            tarantool-version: '3.0'
+            tarantool-version: '3.1'
             pkg-type: 'gc64'
             build: 'script'
 

--- a/.github/workflows/debian-aarch64.yml
+++ b/.github/workflows/debian-aarch64.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check installation of Tarantool
         uses: ./.github/actions/check

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Change Docker image if needed
         run: |

--- a/.github/workflows/fedora-aarch64.yml
+++ b/.github/workflows/fedora-aarch64.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Change Docker image if needed
         run: |

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Change Docker image if needed
         run: |

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -38,10 +38,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8.5'
           cache: pip
@@ -59,7 +59,7 @@ jobs:
             --build brew \
             -d -v
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ github.job }}-${{ Join(matrix.*, '-') }}

--- a/.github/workflows/ubuntu-aarch64.yml
+++ b/.github/workflows/ubuntu-aarch64.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check installation of Tarantool
         uses: ./.github/actions/check

--- a/.github/workflows/ubuntu-aarch64.yml
+++ b/.github/workflows/ubuntu-aarch64.yml
@@ -42,7 +42,7 @@ jobs:
         build: [ 'script', 'manual' ]
         include:
           - dist-version: '22.04'
-            tarantool-version: '3.0'
+            tarantool-version: '3.1'
             build: 'script'
 
     runs-on: [ self-hosted, graviton ]

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
             pkg-type: 'gc64'
         include:
           - dist-version: '22.04'
-            tarantool-version: '3.0'
+            tarantool-version: '3.1'
             pkg-type: 'gc64'
             build: 'script'
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check installation of Tarantool
         uses: ./.github/actions/check


### PR DESCRIPTION
Tarantool 3.1.0 has been released recently, and it's time to check 3.1 in favour of 3.0.